### PR TITLE
Integrate LLM service with translator-service repo

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Test with pytest
       env: 
         PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY }}
+        PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,6 +19,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - env: 
+        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,12 +16,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
     - env: 
         PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
+    steps:
+    - uses: actions/checkout@v3
+
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
@@ -40,3 +40,4 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,7 +16,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env: 
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+      PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -35,8 +37,5 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      env: 
-        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,10 +14,9 @@ permissions:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
-    - env: 
-        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -36,6 +35,8 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      env: 
+        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY }}
       run: |
         pytest
-

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,14 +14,12 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     - env: 
         PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ipytest==0.14.0
 pytest-mock==3.14.0
 mock==5.1.0
 google-cloud-aiplatform
-google-colab
+google-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==3.0.0
 pytest==7.4.0
-ipytest 
-pytest-mock 
-mock
+ipytest==0.14.0
+pytest-mock==3.14.0
+mock==5.1.0
 google-cloud-aiplatform
+google-colab

--- a/src/translator.py
+++ b/src/translator.py
@@ -13,6 +13,7 @@ if os.environ.get('PRIVATE_KEY') != None and os.environ.get('PRIVATE_KEY_ID') !=
   from google.cloud import aiplatform
   print(sha256(os.environ['PRIVATE_KEY_ID'].encode('utf-8')).hexdigest())
   print(sha256(os.environ['PRIVATE_KEY'].encode('utf-8')).hexdigest())
+  print(len(os.environ['PRIVATE_KEY']))
 
   credentials = service_account.Credentials.from_service_account_info(
       {

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,34 +1,76 @@
+import vertexai
+import os
+
+from typing import Callable
+
+PROJECT_ID = "nodebb-416919"
+os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID
+
+from google.colab import auth
+from google.cloud import aiplatform
+
+auth.authenticate_user()
+
+aiplatform.init(
+    # your Google Cloud Project ID or number
+    # environment default used is not set
+    project=PROJECT_ID,
+
+    # the Vertex AI region you will use
+    # defaults to us-central1
+    location='us-central1',
+)
+
+from vertexai.language_models import ChatModel, InputOutputTextPair
+
+chat_model = ChatModel.from_pretrained("chat-bison@001")
+
+def get_translation(post: str) -> str:
+    context = "You are a highly-skilled translator specializing in translating languages to English. You answer truthfully, concisely, and carefully. Translate the following statement to English, do not provide a response with anything other than the English translation.:"
+    # ----------------- DO NOT MODIFY ------------------ #
+
+    parameters = {
+        "temperature": 0.7,  # Temperature controls the degree of randomness in token selection.
+        "max_output_tokens": 256,  # Token limit determines the maximum amount of text output.
+    }
+
+     # ---------------- YOUR CODE HERE ---------------- #
+    chat = chat_model.start_chat(context=context)
+    response = chat.send_message(post, **parameters)
+    return response.text
+
+def get_language(post: str) -> str:
+    # ----------------- DO NOT MODIFY ------------------ #
+    context = "You are a highly trained linguist, able to classify English and non-English text, including various English dialects. Please analyze the following text and determine its language. Respond in one word, the name of the lanugage." # TODO: Insert context
+    parameters = {
+        "temperature": 0.7,  # Temperature controls the degree of randomness in token selection.
+        "max_output_tokens": 256,  # Token limit determines the maximum amount of text output.
+    }
+
+     # ---------------- YOUR CODE HERE ---------------- #
+    chat = chat_model.start_chat(context=context)
+    response = chat.send_message(post, **parameters)
+    return response.text
+
+def is_harmful(post: str) -> str:
+    context = "Determine whether the following text contains potentially harmful or negative content. Reply with Yes or No."
+    parameters = {
+        "temperature": 0.7,
+        "max_output_tokens": 256,
+    }
+
+    chat = chat_model.start_chat(context = context)
+    response = chat.send_message(post, **parameters)
+    return (response.text == "Yes")  
+
 def translate_content(content: str) -> tuple[bool, str]:
-    if content == "这是一条中文消息":
-        return False, "This is a Chinese message"
-    if content == "Ceci est un message en français":
-        return False, "This is a French message"
-    if content == "Esta es un mensaje en español":
-        return False, "This is a Spanish message"
-    if content == "Esta é uma mensagem em português":
-        return False, "This is a Portuguese message"
-    if content  == "これは日本語のメッセージです":
-        return False, "This is a Japanese message"
-    if content == "이것은 한국어 메시지입니다":
-        return False, "This is a Korean message"
-    if content == "Dies ist eine Nachricht auf Deutsch":
-        return False, "This is a German message"
-    if content == "Questo è un messaggio in italiano":
-        return False, "This is an Italian message"
-    if content == "Это сообщение на русском":
-        return False, "This is a Russian message"
-    if content == "هذه رسالة باللغة العربية":
-        return False, "This is an Arabic message"
-    if content == "यह हिंदी में संदेश है":
-        return False, "This is a Hindi message"
-    if content == "นี่คือข้อความภาษาไทย":
-        return False, "This is a Thai message"
-    if content == "Bu bir Türkçe mesajdır":
-        return False, "This is a Turkish message"
-    if content == "Đây là một tin nhắn bằng tiếng Việt":
-        return False, "This is a Vietnamese message"
-    if content == "Esto es un mensaje en catalán":
-        return False, "This is a Catalan message"
-    if content == "This is an English message":
-        return True, "This is an English message"
-    return True, content
+    language = get_language(post)
+    if (language == "English") :
+      return (True, post)
+    else :
+      translation = get_translation(post)
+      if "language model" in translation:
+        return (False, "NodeBB was unable to translate this post\n\n" + post)
+      if is_harmful(translation):
+        return (False, "The translation for this post may contain harmful content. This could due to a translation error.\n\n" + translation)
+      return (False, "The following post has been translated from " + language + "\n\n" + translation)

--- a/src/translator.py
+++ b/src/translator.py
@@ -11,6 +11,7 @@ if os.environ.get('PRIVATE_KEY') != None and os.environ.get('PRIVATE_KEY_ID') !=
   os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID
 
   from google.cloud import aiplatform
+  os.environ['PRIVATE_KEY'] = os.environ['PRIVATE_KEY'].replace('\\\\', '\\')
   print(sha256(os.environ['PRIVATE_KEY_ID'].encode('utf-8')).hexdigest())
   print(sha256(os.environ['PRIVATE_KEY'].encode('utf-8')).hexdigest())
   print(len(os.environ['PRIVATE_KEY']))

--- a/src/translator.py
+++ b/src/translator.py
@@ -3,14 +3,17 @@ import os
 from google.oauth2 import service_account
 from typing import Callable
 from vertexai.language_models import ChatModel, InputOutputTextPair
+from hashlib import sha256
+
 
 if os.environ.get('PRIVATE_KEY') != None and os.environ.get('PRIVATE_KEY_ID') != None:
   PROJECT_ID = "nodebb-416919"
   os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID
 
   from google.cloud import aiplatform
-  print(type(os.environ['PRIVATE_KEY_ID']))
-  print(type(os.environ['PRIVATE_KEY']))
+  print(sha256(os.environ['PRIVATE_KEY_ID'].encode('utf-8')).hexdigest())
+  print(sha256(os.environ['PRIVATE_KEY'].encode('utf-8')).hexdigest())
+
   credentials = service_account.Credentials.from_service_account_info(
       {
     "type": "service_account",

--- a/src/translator.py
+++ b/src/translator.py
@@ -9,13 +9,14 @@ if os.environ.get('PRIVATE_KEY') != None and os.environ.get('PRIVATE_KEY_ID') !=
   os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID
 
   from google.cloud import aiplatform
-
+  print(type(os.environ['PRIVATE_KEY_ID']))
+  print(type(os.environ['PRIVATE_KEY']))
   credentials = service_account.Credentials.from_service_account_info(
       {
     "type": "service_account",
     "project_id": "nodebb-416919",
-    "private_key_id": os.environ['PRIVATE_KEY_ID'],
-    "private_key": os.environ['PRIVATE_KEY'],
+    "private_key_id": str(os.environ['PRIVATE_KEY_ID']),
+    "private_key": str(os.environ['PRIVATE_KEY']),
     "client_email": "nodebb-416919@appspot.gserviceaccount.com",
     "client_id": "112346569395498662874",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
@@ -36,7 +37,7 @@ if os.environ.get('PRIVATE_KEY') != None and os.environ.get('PRIVATE_KEY_ID') !=
       location='us-central1',
       credentials=credentials
   )
-  
+
 chat_model = ChatModel.from_pretrained("chat-bison@001")
 
 def get_translation(post: str) -> str:

--- a/src/translator.py
+++ b/src/translator.py
@@ -11,7 +11,7 @@ if os.environ.get('PRIVATE_KEY') != None and os.environ.get('PRIVATE_KEY_ID') !=
   os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT_ID
 
   from google.cloud import aiplatform
-  os.environ['PRIVATE_KEY'] = os.environ['PRIVATE_KEY'].replace('\\\\', '\\')
+  os.environ['PRIVATE_KEY'] = os.environ['PRIVATE_KEY'].replace('\\n', '\n')
   print(sha256(os.environ['PRIVATE_KEY_ID'].encode('utf-8')).hexdigest())
   print(sha256(os.environ['PRIVATE_KEY'].encode('utf-8')).hexdigest())
   print(len(os.environ['PRIVATE_KEY']))

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -8,7 +8,7 @@ def test_unexpected_language(mocker):
   mocker.return_value.text = "I don't understand your request"
 
   # TODO assert the expected behavior
-  response_eng, response_trans = query_llm_robust("Aquí está su primer ejemplo.")
+  response_eng, response_trans = translate_content("Aquí está su primer ejemplo.")
   assert not response_eng
   assert "NodeBB was unable to translate this post" in response_trans
 
@@ -18,7 +18,7 @@ def test_unexpected_input(mocker):
   mocker.return_value.text = "Translation does not make sense."
 
   # TODO assert the expected behavior
-  response_eng, response_trans = query_llm_robust("😊😊")
+  response_eng, response_trans = translate_content("😊😊")
   assert "NodeBB was unable to translate this post" in response_trans
 
 @patch('vertexai.language_models.ChatSession.send_message')
@@ -27,7 +27,7 @@ def test_dangerous_input(mocker):
   mocker.return_value.text = "Dangerous input."
 
   # TODO assert the expected behavior
-  response_eng, response_trans = query_llm_robust("mata los gérmenes")
+  response_eng, response_trans = translate_content("mata los gérmenes")
   assert not response_eng
   assert "The translation for this post may contain harmful content" in response_trans
 
@@ -37,6 +37,6 @@ def test_empty_input(mocker):
   mocker.return_value.text = ""
 
   # TODO assert the expected behavior
-  response_eng, response_trans = query_llm_robust("What's the weather?")
+  response_eng, response_trans = translate_content("What's the weather?")
   assert not response_eng
   assert "NodeBB was unable to translate this post" in response_trans

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -2,21 +2,15 @@ from src.translator import translate_content
 import vertexai
 from mock import patch
 
-def test_chinese():
-    is_english, translated_content = translate_content("这是一条中文消息")
-    assert is_english == False
-    assert translated_content == "This is a Chinese message"
-
 @patch('vertexai.language_models.ChatSession.send_message')
 def test_unexpected_language(mocker):
   # we mock the model's response to return a random message
   mocker.return_value.text = "I don't understand your request"
 
   # TODO assert the expected behavior
-  content = "Aquí está su primer ejemplo."
-  response_eng, response_trans = translate_content(content)
-  assert response_eng
-  assert response_trans == content
+  response_eng, response_trans = query_llm_robust("Aquí está su primer ejemplo.")
+  assert not response_eng
+  assert "NodeBB was unable to translate this post" in response_trans
 
 @patch('vertexai.language_models.ChatSession.send_message')
 def test_unexpected_input(mocker):
@@ -24,10 +18,8 @@ def test_unexpected_input(mocker):
   mocker.return_value.text = "Translation does not make sense."
 
   # TODO assert the expected behavior
-  content = "😊😊"
-  response_eng, response_trans = translate_content(content)
-  assert response_eng
-  assert response_trans == content
+  response_eng, response_trans = query_llm_robust("😊😊")
+  assert "NodeBB was unable to translate this post" in response_trans
 
 @patch('vertexai.language_models.ChatSession.send_message')
 def test_dangerous_input(mocker):
@@ -35,10 +27,9 @@ def test_dangerous_input(mocker):
   mocker.return_value.text = "Dangerous input."
 
   # TODO assert the expected behavior
-  content = "mata los gérmenes"
-  response_eng, response_trans = translate_content(content)
-  assert response_eng
-  assert response_trans == content
+  response_eng, response_trans = query_llm_robust("mata los gérmenes")
+  assert not response_eng
+  assert "The translation for this post may contain harmful content" in response_trans
 
 @patch('vertexai.language_models.ChatSession.send_message')
 def test_empty_input(mocker):
@@ -46,7 +37,6 @@ def test_empty_input(mocker):
   mocker.return_value.text = ""
 
   # TODO assert the expected behavior
-  content = "What's the weather?"
-  response_eng, response_trans = translate_content(content)
-  assert response_eng
-  assert response_trans == content
+  response_eng, response_trans = query_llm_robust("What's the weather?")
+  assert not response_eng
+  assert "NodeBB was unable to translate this post" in response_trans


### PR DESCRIPTION
Based on online documentation for OAuth, I set up a service account on our NodeBB project that allows authorization to a Vertex API instance for our LLM. I copied over our original test cases as well. Since authentication works on our GCP instance automatically, we only authenticate if the secret private keys are set as global variables.

The following links were useful for doing authentication:
- https://stackoverflow.com/questions/77670495/vertex-ai-sample-notebook-authentication
- https://googleapis.dev/python/google-api-core/latest/auth.html#explicit-credentials